### PR TITLE
[16.0][PERF] sale_stock_prebook : Don't call cancel on empty recordset

### DIFF
--- a/sale_stock_prebook/models/sale_order.py
+++ b/sale_stock_prebook/models/sale_order.py
@@ -61,6 +61,7 @@ class SaleOrder(models.Model):
 
     def release_reservation(self):
         pickings = self._get_reservation_pickings()
-        pickings.action_cancel()
-        pickings.group_id.sudo().unlink()
-        pickings.sudo().unlink()
+        if pickings:
+            pickings.action_cancel()
+            pickings.group_id.sudo().unlink()
+            pickings.sudo().unlink()


### PR DESCRIPTION
Small performance improvement. Don't call cancel on empty recordset

fwp #7 from 14.0 to 16.0