### PR TITLE
[FIX] sale_stock_prebook: correctly position 'no_sale_stock_prebook' ield

### DIFF
--- a/sale_stock_prebook/views/stock_route_views.xml
+++ b/sale_stock_prebook/views/stock_route_views.xml
@@ -5,7 +5,14 @@
         <field name="inherit_id" ref="stock.stock_location_route_form_view" />
         <field name="model">stock.route</field>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='warehouse_ids']" position="after">
+
+            <!-- We want to place it after the field 'warehouse_ids' but the later is inside an
+            .o_row <div> so we need to make sure we are inside the containing <group> to ensure
+            the label is displayed in the UI -->
+            <xpath
+                expr="//field[@name='warehouse_ids']/ancestor::group[1]"
+                position="inside"
+            >
                 <field name="no_sale_stock_prebook" string="No Prebook Stock" />
             </xpath>
         </field>


### PR DESCRIPTION

The 'no_sale_stock_prebook' field was placed inside a .o_row <div> making it appear without its label and next to another boolean checkbox which made the UI confusing.